### PR TITLE
fix: the extract-release-notes in extract-release-notes.mjs

### DIFF
--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,10 +1,21 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
 
 const tag = process.argv[2] || process.env.GITHUB_REF_NAME
 const outputPath = process.argv[3] || 'release-notes.md'
 
 if (!tag) {
   throw new Error('Usage: node scripts/extract-release-notes.mjs <tag> [output]')
+}
+
+if (!/^v?[\w.-]+$/.test(tag)) {
+  throw new Error(`Invalid tag: ${tag}`)
+}
+
+const resolvedOutputPath = resolve(outputPath)
+const relativeOutputPath = relative(process.cwd(), resolvedOutputPath)
+if (relativeOutputPath.startsWith('..') || resolve(process.cwd(), relativeOutputPath) !== resolvedOutputPath) {
+  throw new Error(`Invalid output path: ${outputPath}`)
 }
 
 const version = tag.replace(/^v/, '')


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/extract-release-notes.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/extract-release-notes.mjs:3` |
| **Assessment** | Likely exploitable |

**Description**: The extract-release-notes.mjs script accepts command line arguments and environment variables without any input validation. The tag value from process.argv[2] or GITHUB_REF_NAME environment variable is used directly in file path construction, and the outputPath parameter is used without sanitization in writeFileSync operations.

## Evidence

**Exploitation scenario**: An attacker who controls the GITHUB_REF_NAME environment variable in a CI/CD pipeline can inject path traversal sequences (e.g., '../../../etc/cron.d/backdoor') or malicious content.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/extract-release-notes.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
