### PR TITLE
fix(client): read the uiWorkspace service at call time so workspace picks navigate

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3466,7 +3466,10 @@ window.__ModuleLoader__.load({
 				zh,
 				en
 			}), "dsh-archive-manager: dictionaries");
-			const uiWorkspace = ctx.get("uiWorkspace");
+			// Resolve the navigation service lazily: this plugin provides the fallback
+			// implementation during its own apply, and cordis strict ctx.get only
+			// returns a service once the providing fiber is ACTIVE.
+			const uiWorkspaceAt = () => ctx.get("uiWorkspace");
 			const searchSessions = async (query, signal) => {
 				const result = await ctx.sessions.search(query, signal);
 				if (!result.ok) throw new Error(result.error.message);
@@ -3513,6 +3516,7 @@ window.__ModuleLoader__.load({
 			};
 			const browserInjected = () => ({
 				startSession: (workspaceId) => {
+					const uiWorkspace = uiWorkspaceAt();
 					if (uiWorkspace !== void 0) uiWorkspace.startSession(workspaceId);
 					else ctx.workspaces.startSession(workspaceId);
 				},


### PR DESCRIPTION
## Summary

Adding or picking a workspace in the sidebar on DSH `v0.1.2-alpha.1` always fails with the folder-error dialog:

> 无法打开文件夹 — `ctx.workspaces.startSession is not a function`

The root cause is an apply-time capture of a service this plugin itself provides. `applyWorkspaceBrowser` runs synchronously after `provideUiWorkspace(ctx)`:

```js
function provideUiWorkspace(ctx) {
  if (ctx.get("uiWorkspace") !== void 0) return () => {};
  ...
  const dispose = ctx.provide("uiWorkspace", service); // registered on THIS plugin's fiber
  ...
}

function applyWorkspaceBrowser(ctx) {
  ...
  const uiWorkspace = ctx.get("uiWorkspace"); // ← undefined, forever
```

Cordis `ctx.get` is strict: it only returns a service whose **providing fiber is ACTIVE**. During the plugin's own `apply` the fiber is still LOADING, so reading back the service it just provided returns `undefined`. The captured closure value never refreshes, so every `browserInjected().startSession(...)` falls into the legacy branch:

```js
if (uiWorkspace !== void 0) uiWorkspace.startSession(workspaceId);
else ctx.workspaces.startSession(workspaceId); // ← DSH 0.1.2 removed this method
```

DSH `0.1.2` migrated workspace navigation from `IWorkspaces.startSession` to the `uiWorkspace` service (which is exactly why `provideUiWorkspace` exists), so the fallback throws a TypeError on every workspace pick/add. The pick flow's error surface then renders the message in the folder-error dialog.

## Fix

Resolve the service inside the callback instead of capturing it at apply time. By click time the providing fiber is ACTIVE and `ctx.get` returns the service:

```js
const uiWorkspaceAt = () => ctx.get("uiWorkspace");
...
startSession: (workspaceId) => {
  const uiWorkspace = uiWorkspaceAt();
  if (uiWorkspace !== void 0) uiWorkspace.startSession(workspaceId);
  else ctx.workspaces.startSession(workspaceId);
},
```

The legacy branch is kept verbatim for older hosts, so nothing changes for DSH ≤ 0.1.1.

## Verification

- Reproduced the cordis semantics against the shipped framework (`@deepseek-ai/cordis` from the alpha install): `ctx.provide("x", …)` followed by `ctx.get("x")` inside the same `apply` returns `undefined`; the same `ctx.get` after activation returns the service.
- Applied this patch to the installed `@michengai/dsh-archive-manager@0.1.18` bundle in a live `dsh web` session: sidebar workspace add and pick now create/open the target session with no error dialog; archive flows are untouched.
- `pnpm test` (this repo): 66 passed, 0 failed.

## Environment

- DSH `v0.1.2-alpha.1` (dsh web), plugin `@michengai/dsh-archive-manager@0.1.18`